### PR TITLE
Add selinux setup for CentOS6 nginx

### DIFF
--- a/linux/install-centos6.sh
+++ b/linux/install-centos6.sh
@@ -13,6 +13,7 @@ cp settings.env setup_omero_ice35.sh ~omero
 su - omero -c "bash -eux setup_omero_ice35.sh"
 
 bash -eux setup_nginx_centos6.sh
+bash -eux setup_nginx_centos6_selinux.sh
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/linux/setup_nginx_centos6_selinux.sh
+++ b/linux/setup_nginx_centos6_selinux.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [ $(getenforce) != Disabled ]; then
+    yum -y install policycoreutils-python
     setsebool -P httpd_read_user_content 1
     setsebool -P httpd_enable_homedirs 1
     semanage port -a -t http_port_t -p tcp 4080

--- a/linux/setup_nginx_centos6_selinux.sh
+++ b/linux/setup_nginx_centos6_selinux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $(getenforce) != Disabled ]; then
+    setsebool -P httpd_read_user_content 1
+    setsebool -P httpd_enable_homedirs 1
+    semanage port -a -t http_port_t -p tcp 4080
+fi


### PR DESCRIPTION
The external Nginx package on CentOS6 requires changes to the selnux policy.